### PR TITLE
Improve Docker image publishing workflow and introduce stable tag strategy

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Normalize image name
         shell: bash
@@ -34,7 +34,7 @@ jobs:
           echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME_LC }}
           tags: |
@@ -54,7 +54,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,63 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  docker:
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Normalize image name
+        shell: bash
+        run: |
+          echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+          echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME_LC }}
+          tags: |
+            type=raw,value=dev,enable=${{ github.event_name == 'push' }}
+            type=ref,event=branch,enable=${{ github.event_name == 'push' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
+            type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=sha,prefix=sha-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          no-cache: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,24 +12,17 @@ on:
         required: false
 
 env:
-  REGISTRY_GHCR: ghcr.io
   REGISTRY_DOCKER: docker.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
       contents: write    # For creating GitHub Releases
-      packages: write    # For pushing to GHCR
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Lowercase image name
-        id: repo
-        run: echo "image_name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+        uses: actions/checkout@v6
 
       - name: Determine version tag
         id: version
@@ -52,27 +45,20 @@ jobs:
           fi
 
       - name: Set up QEMU (multi-arch)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY_GHCR }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY_DOCKER }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -82,9 +68,7 @@ jobs:
             BRANCH=${{ github.ref_name }}
             NOW=${{ github.event.head_commit.timestamp }}
           tags: |
-            ${{ env.REGISTRY_GHCR }}/${{ steps.repo.outputs.image_name }}:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY_DOCKER }}/${{ secrets.DOCKERHUB_USERNAME }}/fgc-remaster:${{ steps.version.outputs.version }}
-            ${{ steps.version.outputs.is_latest == 'true' && format('{0}/{1}:latest', env.REGISTRY_GHCR, steps.repo.outputs.image_name) || '' }}
             ${{ steps.version.outputs.is_latest == 'true' && format('{0}/{1}/fgc-remaster:latest', env.REGISTRY_DOCKER, secrets.DOCKERHUB_USERNAME) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -104,7 +88,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.is_dev == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: "v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

This PR simplifies and modernizes the Docker image publishing process by introducing a dedicated GHCR workflow with a clearer tag strategy.

The previous workflow relied on manually managed version tags (`v1.1`, `v1.1d`, etc.) and mixed release creation, Docker publishing and version handling in a single pipeline.

The new workflow separates development builds from stable releases and aligns the published container tags with common container registry practices.

## Changes

### Development builds

Every push to `main` or `dev` automatically publishes development images.

Generated tags:

```text
:dev
:<branch-name>
:sha-<commit>
```

Examples:

```text
ghcr.io/p-adamiec/free-games-claimer-remaster:dev
ghcr.io/p-adamiec/free-games-claimer-remaster:main
ghcr.io/p-adamiec/free-games-claimer-remaster:sha-a1b2c3d
```

This ensures that testers can always pull the latest development version without waiting for a release.

### Release builds

When a GitHub Release is published, the workflow automatically publishes:

```text
:vX.Y.Z
:latest
:sha-<commit>
```

Example:

```text
ghcr.io/p-adamiec/free-games-claimer-remaster:v1.1
ghcr.io/p-adamiec/free-games-claimer-remaster:latest
```

This makes `latest` represent the newest stable release instead of the newest commit.

## Benefits

### Stable deployments

Users running:

```yaml
image: ghcr.io/p-adamiec/free-games-claimer-remaster:latest
```

will always receive the newest official release and will no longer accidentally receive development builds.

### Easier testing

Developers and testers can switch to:

```yaml
image: ghcr.io/p-adamiec/free-games-claimer-remaster:dev
```

to immediately test the newest development state.

### Better traceability

Every build receives a unique SHA tag:

```text
:sha-<commit>
```

allowing exact rollback and debugging against a specific commit.

### Repository independent

The workflow automatically derives the image name from the repository and owner instead of relying on hardcoded values, making forks immediately usable without modification.

## Validation

The workflow was tested against a forked repository and successfully generated the expected image tags.

The attached screenshot shows the generated package versions/tags in GHCR.

<img width="1272" height="574" alt="grafik" src="https://github.com/user-attachments/assets/a9ffe836-ef09-47d9-9fdc-5716895d9bf5" />

## Scope

This PR only changes the Docker publishing workflow.

No application code, runtime logic or container functionality has been modified.